### PR TITLE
add jtif into pillow_permit_extensions

### DIFF
--- a/dist/imgconv/main.py
+++ b/dist/imgconv/main.py
@@ -1,11 +1,11 @@
+import pefile
 import pdf2image
 import argparse
-import logging
-import pefile
-import struct
 import io
-from typing import Optional, Any, Dict, NamedTuple, Union, List
-from PIL import ImageDraw, UnidentifiedImageError, Image, ImageFilter
+import logging
+import struct
+from PIL import ImageFilter, UnidentifiedImageError, ImageDraw, Image
+from typing import Any, NamedTuple, Union, List, Optional, Dict
 from pathlib import Path
 
 
@@ -513,6 +513,7 @@ def convert(img_input: Path, img_output: Path, preprocessor: Preprocessor, pdf2i
         ".ico",
         ".im",
         ".jpeg",
+        ".jfif",
         ".jpg",
         ".msp",
         ".pcx",

--- a/src/main.py
+++ b/src/main.py
@@ -210,6 +210,7 @@ def convert(img_input: Path, img_output: Path, preprocessor: Preprocessor, pdf2i
         ".ico",
         ".im",
         ".jpeg",
+        ".jfif",
         ".jpg",
         ".msp",
         ".pcx",


### PR DESCRIPTION
Pillow can write and read `.jtif` files, so add `".jtif"` into pillow_permit_extensions.
see  [pillow document](https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html?highlight=jfif#jpeg)